### PR TITLE
A proposed schema for Edge Agent Node metrics.

### DIFF
--- a/Common/Alerts-v1.json
+++ b/Common/Alerts-v1.json
@@ -1,0 +1,42 @@
+{
+  "$id": "https://raw.githubusercontent.com/AMRC-FactoryPlus/schemas/main/Common/Alerts-v1.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Alerts which can be raised by a node.",
+  "type": "object",
+  "properties": {
+    "Schema_UUID": {
+      "const": "39e0091f-4e68-40f7-b082-1887d6ad2399"
+    },
+    "Instance_UUID": {
+      "description": "The unique identifier for this object. (A UUID specified by RFC4122).",
+      "type": "string",
+      "format": "uuid"
+    }
+  },
+  "patternProperties": {
+    "^[a-zA-Z0-9_]*$": {
+      "description": "A name for this alert.",
+      "type": "object",
+      "properties": {
+        "Type": {
+          "description": "An alert type registered in the ConfigDB.",
+          "type": "string",
+          "format": "uuid"
+        },
+        "Active": {
+          "description": "Is this alert active (raised)?",
+          "type": "boolean"
+        },
+        "Links": {
+          "$comment": "Additional information about what this alert relates to.",
+          "$ref": "https://raw.githubusercontent.com/AMRC-FactoryPlus/schemas/main/Common/Links-v1.json"
+        }
+      },
+      "required": ["Type", "Active"]
+    }
+  },
+  "required": [
+    "Schema_UUID",
+    "Instance_UUID"
+  ]
+}

--- a/Common/Links-v1.json
+++ b/Common/Links-v1.json
@@ -1,0 +1,39 @@
+{
+  "$id": "https://raw.githubusercontent.com/AMRC-FactoryPlus/schemas/main/Common/Links-v1.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Links between objects",
+  "type": "object",
+  "properties": {
+    "Schema_UUID": {
+      "const": "2fed10c7-de5f-4023-89b7-9aeb10afe60b"
+    },
+    "Instance_UUID": {
+      "description": "The unique identifier for this object. (A UUID specified by RFC4122).",
+      "type": "string",
+      "format": "uuid"
+    }
+  },
+  "patternProperties": {
+    "^[a-zA-Z0-9_]*$": {
+      "description": "A name for this link.",
+      "type": "object",
+      "properties": {
+        "Target": {
+          "description": "The UUID of the object linked to.",
+          "type": "string",
+          "format": "uuid"
+        },
+        "Relation": {
+          "description": "A UUID identifying the kind of link this is.",
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      "required": ["Target", "Relation"]
+    }
+  },
+  "required": [
+    "Schema_UUID",
+    "Instance_UUID"
+  ]
+}

--- a/Edge_Agent/Edge_Agent-v1.json
+++ b/Edge_Agent/Edge_Agent-v1.json
@@ -1,0 +1,54 @@
+{
+  "$id": "https://raw.githubusercontent.com/AMRC-FactoryPlus/schemas/main/Edge_Agent/Edge_Agent-v1.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Schema for the Edge Agent Node metrics.",
+  "type": "object",
+  "properties": {
+    "Schema_UUID": {
+      "const": "15360868-2f35-4b52-990b-49329fb246fe"
+    },
+    "Instance_UUID": {
+      "description": "The unique identifier for this object. (A UUID specified by RFC4122).",
+      "type": "string",
+      "format": "uuid"
+    },
+    "Config_Revision": {
+      "description": "The revision of our config file we are currently using.",
+      "type": "string",
+      "format": "uuid"
+    },
+    "Alerts": {
+      "description": "Alerts raised by the Edge Agent",
+      "allOf": {
+        { "$ref": "https://raw.githubusercontent.com/AMRC-FactoryPlus/schemas/main/Common/Alerts-v1.json" },
+        {
+          "type": "object",
+          "properties": {
+            "Config_File": {
+              "description": "Indicates a problem fetching our config file.",
+              "type": "object",
+              "properties": {
+                "Type": {
+                  "const": "c414c68b-5014-4e46-a0b4-d5f7f8df1d9f"
+                }
+              }
+            }
+          },
+          "required": ["Config_File"],
+          "patternProperties": {
+            "^Connection_[A-Za-z0-9_]+$": {
+              "description": "Indicates a problem with a particular device connection.",
+              "type": "object",
+              "properties": {
+                "Type": {
+                  "const": "633a7da3-ea2a-4e3f-8e84-35691a07465f"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "required": ["Schema_UUID", "Instance_UUID", "Config_File", "Alerts"]
+}


### PR DESCRIPTION
* Create a schema for the Edge Agent Node which allows the Edge Agent to publish information about its own operation.
* Publish the revision of the config file in use to allow for reconciliation.
* Allow the Edge Agent to raise alerts over the infrastructure.
* Create a generic Alerts schema to support alerting.
* Create a generic Links schema to support devices which need to reference other devices.