### PR TITLE
Refactor schema structure of Status_Flags

### DIFF
--- a/PLC/PLC-v1.json
+++ b/PLC/PLC-v1.json
@@ -58,22 +58,8 @@
         "Status_Flags": {
             "type": "object",
             "patternProperties": {
-                "^[a-zA-z_]*$": {
-                    "allOf": [
-                        {
-                            "$ref": "https://raw.githubusercontent.com/AMRC-FactoryPlus/schemas/main/Common/Metric-v1.json"
-                        },
-                        {
-                            "type": "object",
-                            "properties": {
-                                "Sparkplug_Type": {
-                                    "enum": [
-                                        "Boolean"
-                                    ]
-                                }
-                            }
-                        }
-                    ]
+                "^[a-zA-Z0-9_]*$": {
+                    "$ref": "https://raw.githubusercontent.com/AMRC-FactoryPlus/schemas/main/PLC/Status_Flag-v1.json"
                 }
             }
         }

--- a/PLC/Status_Flag-v1.json
+++ b/PLC/Status_Flag-v1.json
@@ -1,0 +1,39 @@
+{
+  "$id": "https://raw.githubusercontent.com/AMRC-FactoryPlus/schemas/main/PLC/Status_Flag-v1.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Status Flag",
+  "type": "object",
+  "properties": {
+    "Schema_UUID": {
+      "const": "4171ff9f-e852-4a15-98c1-b49361e8e506"
+    },
+    "Instance_UUID": {
+      "description": "The unique identifier for this object. (A UUID specified by RFC4122).",
+      "type": "string",
+      "format": "uuid"
+    },
+    "Status": {
+      "allOf": [
+        {
+          "$ref": "https://raw.githubusercontent.com/AMRC-FactoryPlus/schemas/main/Common/Metric-v1.json"
+        },
+        {
+          "properties": {
+            "Sparkplug_Type": {
+              "enum": [
+                "String"
+              ]
+            },
+            "Documentation": {
+              "default": "The value of the status for this flag"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "required": [
+    "Schema_UUID",
+    "Instance_UUID"
+  ]
+}


### PR DESCRIPTION
Simplified the Status_Flags structure in PLC-v1.json by referencing to a new file, Status_Flag-v1.json. The inclusion of numeric characters in patternProperties is also now allowed. The new Status_Flag-v1.json file contains boilerplate for status flags, with details previously included in PLC-v1.json. Refactoring is done for readability and modularity of code.