### PR TITLE
Add support for Open Protocol in Device Connection

### DIFF
--- a/Device_Connection.json
+++ b/Device_Connection.json
@@ -20,7 +20,8 @@
                 "REST",
                 "S7",
                 "UDP",
-                "MTConnect"
+                "MTConnect",
+                "Open Protocol"
             ],
             "minLength": 1
         },
@@ -116,6 +117,33 @@
                     "type": "number",
                     "title": "Keep Alive Interval (sec)",
                     "default": 60
+                }
+            }
+        },
+        "OpenProtocolConnDetails": {
+            "type": "object",
+            "title": "Open Protocol Details",
+            "options": {
+                "dependencies": {
+                    "connType": "Open Protocol"
+                },
+                "collapsed": false
+            },
+            "required": [
+                "host",
+                "port"
+            ],
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "title": "Hostname/IP",
+                    "minLength": 1
+                },
+                "port": {
+                    "type": "number",
+                    "title": "Port",
+                    "minLength": 1,
+                    "default": 4545
                 }
             }
         },


### PR DESCRIPTION
This commit includes the addition of "Open Protocol" in the communication protocol options, and defines connection details associated with it, which includes required host and port of the device under the new section "OpenProtocolConnDetails". This change was needed to allow devices that use "Open Protocol" to be seamlessly integrated into our system.