### PR TITLE
Refactor Three_Phase_Circuit schema for flexibility

### DIFF
--- a/Power/Three_Phase_Circuit-v1.json
+++ b/Power/Three_Phase_Circuit-v1.json
@@ -20,30 +20,8 @@
         },
         "Phases": {
             "type": "object",
-            "properties": {
-                "L1": {
-                    "type": "object",
-                    "properties": {
-                        "Characteristics": {
-                            "$ref": "https://raw.githubusercontent.com/AMRC-FactoryPlus/schemas/main/Power/Phase-v2.json"
-                        },
-                        "Loads": {
-                            "$ref": "https://raw.githubusercontent.com/AMRC-FactoryPlus/schemas/main/Power/Single_Phase_Circuit-v1.json"
-                        }
-                    }
-                },
-                "L2": {
-                    "type": "object",
-                    "properties": {
-                        "Characteristics": {
-                            "$ref": "https://raw.githubusercontent.com/AMRC-FactoryPlus/schemas/main/Power/Phase-v2.json"
-                        },
-                        "Loads": {
-                            "$ref": "https://raw.githubusercontent.com/AMRC-FactoryPlus/schemas/main/Power/Single_Phase_Circuit-v1.json"
-                        }
-                    }
-                },
-                "L3": {
+            "patternProperties": {
+                "^L[123]$": {
                     "type": "object",
                     "properties": {
                         "Characteristics": {


### PR DESCRIPTION
Reduced the repetitive schema for L1, L2, and L3 properties in the Three_Phase_Circuit-v1.json by converting them to a patternProperties element. This enhancement allows any property that matches the pattern "^L[123]$" to share the same schema definition, thus increasing flexibility and maintainability in the schema structure. The file also now ends with a newline, adhering to JSON format standards.