### PR TITLE
Simplify Three_Phase_Circuit-v1.json structure

### DIFF
--- a/Power/Three_Phase_Circuit-v1.json
+++ b/Power/Three_Phase_Circuit-v1.json
@@ -22,15 +22,7 @@
             "type": "object",
             "patternProperties": {
                 "^L[123]$": {
-                    "type": "object",
-                    "properties": {
-                        "Characteristics": {
-                            "$ref": "https://raw.githubusercontent.com/AMRC-FactoryPlus/schemas/main/Power/Phase-v2.json"
-                        },
-                        "Loads": {
-                            "$ref": "https://raw.githubusercontent.com/AMRC-FactoryPlus/schemas/main/Power/Single_Phase_Circuit-v1.json"
-                        }
-                    }
+                    "$ref": "https://raw.githubusercontent.com/AMRC-FactoryPlus/schemas/main/Power/Single_Phase_Circuit-v1.json"
                 }
             }
         },


### PR DESCRIPTION
Replaced the 'L[123]' patternProperties object structure with a single $ref in the Three_Phase_Circuit-v1.json file. This was done to reduce unnecessary complexity and improve readability of our JSON structure.