### PR TITLE
Corrected references to Link-v1.json in several JSON files

### DIFF
--- a/Common/Alerts-v1.json
+++ b/Common/Alerts-v1.json
@@ -31,7 +31,7 @@
           "type": "object",
           "patternProperties": {
             "^[a-zA-Z0-9_]*$": {
-              "$ref": "https://raw.githubusercontent.com/AMRC-FactoryPlus/schemas/main/Common/Link-v1.json   "
+              "$ref": "https://raw.githubusercontent.com/AMRC-FactoryPlus/schemas/main/Common/Link-v1.json"
             }
           }
         }

--- a/Power/Power_Monitoring-v2.json
+++ b/Power/Power_Monitoring-v2.json
@@ -19,7 +19,7 @@
       "type": "object",
       "patternProperties": {
         "^[a-zA-Z0-9_]*$": {
-          "$ref": "https://raw.githubusercontent.com/AMRC-FactoryPlus/schemas/main/Common/Link-v1.json   "
+          "$ref": "https://raw.githubusercontent.com/AMRC-FactoryPlus/schemas/main/Common/Link-v1.json"
         }
       }
     },

--- a/Power/Single_Phase_Circuit-v1.json
+++ b/Power/Single_Phase_Circuit-v1.json
@@ -19,7 +19,7 @@
             "type": "object",
             "patternProperties": {
                 "^[a-zA-Z0-9_]*$": {
-                    "$ref": "https://raw.githubusercontent.com/AMRC-FactoryPlus/schemas/main/Common/Link-v1.json   "
+                    "$ref": "https://raw.githubusercontent.com/AMRC-FactoryPlus/schemas/main/Common/Link-v1.json"
                 }
             }
         },

--- a/Power/Three_Phase_Circuit-v1.json
+++ b/Power/Three_Phase_Circuit-v1.json
@@ -19,7 +19,7 @@
             "type": "object",
             "patternProperties": {
                 "^[a-zA-Z0-9_]*$": {
-                    "$ref": "https://raw.githubusercontent.com/AMRC-FactoryPlus/schemas/main/Common/Link-v1.json   "
+                    "$ref": "https://raw.githubusercontent.com/AMRC-FactoryPlus/schemas/main/Common/Link-v1.json"
                 }
             }
         },


### PR DESCRIPTION
Removed extra whitespace at the end of '$ref' URLs, which referred to Link-v1.json, in several JSON schema files. These unnecessary spaces might have led to errors or unexpected behaviours in systems reliant on these schemas.