### PR TITLE
Add ASCII TCP connection details to Device_Connection.json

### DIFF
--- a/Device_Connection.json
+++ b/Device_Connection.json
@@ -21,7 +21,8 @@
                 "S7",
                 "UDP",
                 "MTConnect",
-                "Open Protocol"
+                "Open Protocol",
+                "ASCII TCP"
             ],
             "minLength": 1
         },
@@ -144,6 +145,40 @@
                     "title": "Port",
                     "minLength": 1,
                     "default": 4545
+                }
+            }
+        },
+        "ASCIITCPConnDetails": {
+            "type": "object",
+            "title": "ASCII TCP Details",
+            "options": {
+                "dependencies": {
+                    "connType": "ASCII TCP"
+                },
+                "collapsed": false
+            },
+            "required": [
+                "ip",
+                "inputs",
+                "outputs"
+            ],
+            "properties": {
+                "ip": {
+                    "type": "string",
+                    "title": "IP",
+                    "minLength": 3
+                },
+                "inputs": {
+                    "type": "number",
+                    "title": "Inputs",
+                    "minLength": 1,
+                    "default": 4
+                },
+                "outputs": {
+                    "type": "number",
+                    "title": "Outputs",
+                    "minLength": 1,
+                    "default": 4
                 }
             }
         },


### PR DESCRIPTION
Adjusted the Device_Connection.json to include ASCII TCP in the list of supported connection types. Moreover, an additional section for specifying "ASCII TCP Details" was added to include necessary parameters for such connection like "IP", "inputs", and "outputs". This change is necessary to support devices using ASCII TCP connection.