### PR TITLE
Jh press schema changes

### DIFF
--- a/Press/Press-v1.json
+++ b/Press/Press-v1.json
@@ -2,10 +2,15 @@
   "$id": "https://raw.githubusercontent.com/AMRC-FactoryPlus/schemas/main/Press/Press-v1.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
-  "required": [
-    "Schema_UUID",
-    "Instance_UUID"
-  ],
+  "properties": {
+    "Schema_UUID": {
+      "const": "c8318a2e-ceb8-46cb-89d8-3483ce1840a4"
+    },
+    "Instance_UUID": {
+      "description": "The unique identifier for this object. (A UUID specified by RFC4122).",
+      "type": "string",
+      "format": "uuid"
+    },
   "Tools": {
     "Schema_UUID": {
       "const": "c8318a2e-ceb8-46cb-89d8-3483ce1840a4"
@@ -68,8 +73,6 @@
           }
         }
       ],
-      "uuid": "a9d2f476-25fe-49ba-a1d4-a70ea48c756a",
-      "index": 0
     },
     "Cylinder_Position": {
       "allOf": [
@@ -89,8 +92,6 @@
           }
         }
       ],
-      "uuid": "49aa6073-a219-4722-8968-de999b1079cc",
-      "index": 1
     },
     "Tool_Gap": {
       "allOf": [
@@ -113,8 +114,6 @@
           }
         }
       ],
-      "uuid": "041c5acd-07bd-4975-a2e2-89da4b6e693c",
-      "index": 2
     },
     "Sequence_Step": {
       "allOf": [
@@ -140,8 +139,6 @@
           }
         }
       ],
-      "uuid": "12983e86-90b1-4835-a161-c1dffb59d79c",
-      "index": 3
     },
     "Sequence_Timer": {
       "allOf": [
@@ -164,8 +161,6 @@
           }
         }
       ],
-      "uuid": "2bb9eec1-1298-4215-9753-025f5d23618e",
-      "index": 4
     },
     "Step_Timer": {
       "allOf": [
@@ -188,8 +183,6 @@
           }
         }
       ],
-      "uuid": "152138f2-1be9-4be1-a6e4-14bb3a85b663",
-      "index": 5
     },
     "Healthy": {
       "allOf": [
@@ -209,8 +202,6 @@
           }
         }
       ],
-      "uuid": "5cb7a9f7-93e6-47de-9b44-035f7d456f43",
-      "index": 6
     },
     "In_Auto_Sequence": {
       "allOf": [
@@ -230,8 +221,6 @@
           }
         }
       ],
-      "uuid": "c9713529-a6e1-4fed-bdb3-877c773876ca",
-      "index": 7
     },
     "Ejectors": {
       "type": "object",
@@ -254,8 +243,6 @@
               }
             }
           ],
-          "uuid": "4dd1c334-a8d9-48a8-8584-792636a524e9",
-          "index": 0
         },
         "Lowered": {
           "allOf": [
@@ -275,8 +262,6 @@
               }
             }
           ],
-          "uuid": "17e3836d-45b8-43aa-8a5e-add00d0d446a",
-          "index": 1
         }
       },
       "required": []

--- a/Press/Press-v1.json
+++ b/Press/Press-v1.json
@@ -11,15 +11,6 @@
       "type": "string",
       "format": "uuid"
     },
-  "Tools": {
-    "Schema_UUID": {
-      "const": "c8318a2e-ceb8-46cb-89d8-3483ce1840a4"
-    },
-    "Instance_UUID": {
-      "description": "The unique identifier for this object. (A UUID specified by RFC4122).",
-      "type": "string",
-      "format": "uuid"
-    },
     "Tools": {
       "patternProperties": {
         "^[a-zA-Z0-9_]*$": {

--- a/Press/Press-v1.json
+++ b/Press/Press-v1.json
@@ -63,7 +63,7 @@
             }
           }
         }
-      ],
+      ]
     },
     "Cylinder_Position": {
       "allOf": [
@@ -82,7 +82,7 @@
             }
           }
         }
-      ],
+      ]
     },
     "Tool_Gap": {
       "allOf": [
@@ -104,7 +104,7 @@
             }
           }
         }
-      ],
+      ]
     },
     "Sequence_Step": {
       "allOf": [
@@ -129,7 +129,7 @@
             }
           }
         }
-      ],
+      ]
     },
     "Sequence_Timer": {
       "allOf": [
@@ -151,7 +151,7 @@
             }
           }
         }
-      ],
+      ]
     },
     "Step_Timer": {
       "allOf": [
@@ -173,7 +173,7 @@
             }
           }
         }
-      ],
+      ]
     },
     "Healthy": {
       "allOf": [
@@ -192,7 +192,7 @@
             }
           }
         }
-      ],
+      ]
     },
     "In_Auto_Sequence": {
       "allOf": [
@@ -211,7 +211,7 @@
             }
           }
         }
-      ],
+      ]
     },
     "Ejectors": {
       "type": "object",
@@ -233,7 +233,7 @@
                 }
               }
             }
-          ],
+          ]
         },
         "Lowered": {
           "allOf": [
@@ -252,20 +252,24 @@
                 }
               }
             }
-          ],
+          ]
         }
       },
       "required": []
     },
     "Heaters": {
-      "uuid": "429529d2-fb55-4b07-80b8-a145d931fbef",
-      "index": 15,
-      "patternProperties": {
-        "^[a-zA-Z0-9_]*$": {
-          "$ref": "https://raw.githubusercontent.com/AMRC-FactoryPlus/schemas/main/Press/Heater-v1.json"
-        }
-      },
-      "type": "object"
-    }
+    "uuid": "429529d2-fb55-4b07-80b8-a145d931fbef",
+    "index": 15,
+    "patternProperties": {
+      "^[a-zA-Z0-9_]*$": {
+        "$ref": "https://raw.githubusercontent.com/AMRC-FactoryPlus/schemas/main/Press/Heater-v1.json"
+      }
+    },
+    "type": "object"
   }
+  },
+  "required": [
+    "Schema_UUID",
+    "Instance_UUID"
+  ]
 }

--- a/Press/Press-v1.json
+++ b/Press/Press-v1.json
@@ -2,7 +2,11 @@
   "$id": "https://raw.githubusercontent.com/AMRC-FactoryPlus/schemas/main/Press/Press-v1.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
-  "properties": {
+  "required": [
+    "Schema_UUID",
+    "Instance_UUID"
+  ],
+  "Tools": {
     "Schema_UUID": {
       "const": "c8318a2e-ceb8-46cb-89d8-3483ce1840a4"
     },
@@ -63,7 +67,9 @@
             }
           }
         }
-      ]
+      ],
+      "uuid": "a9d2f476-25fe-49ba-a1d4-a70ea48c756a",
+      "index": 0
     },
     "Cylinder_Position": {
       "allOf": [
@@ -82,7 +88,9 @@
             }
           }
         }
-      ]
+      ],
+      "uuid": "49aa6073-a219-4722-8968-de999b1079cc",
+      "index": 1
     },
     "Tool_Gap": {
       "allOf": [
@@ -104,7 +112,9 @@
             }
           }
         }
-      ]
+      ],
+      "uuid": "041c5acd-07bd-4975-a2e2-89da4b6e693c",
+      "index": 2
     },
     "Sequence_Step": {
       "allOf": [
@@ -129,7 +139,9 @@
             }
           }
         }
-      ]
+      ],
+      "uuid": "12983e86-90b1-4835-a161-c1dffb59d79c",
+      "index": 3
     },
     "Sequence_Timer": {
       "allOf": [
@@ -151,7 +163,9 @@
             }
           }
         }
-      ]
+      ],
+      "uuid": "2bb9eec1-1298-4215-9753-025f5d23618e",
+      "index": 4
     },
     "Step_Timer": {
       "allOf": [
@@ -173,7 +187,9 @@
             }
           }
         }
-      ]
+      ],
+      "uuid": "152138f2-1be9-4be1-a6e4-14bb3a85b663",
+      "index": 5
     },
     "Healthy": {
       "allOf": [
@@ -192,7 +208,9 @@
             }
           }
         }
-      ]
+      ],
+      "uuid": "5cb7a9f7-93e6-47de-9b44-035f7d456f43",
+      "index": 6
     },
     "In_Auto_Sequence": {
       "allOf": [
@@ -211,7 +229,9 @@
             }
           }
         }
-      ]
+      ],
+      "uuid": "c9713529-a6e1-4fed-bdb3-877c773876ca",
+      "index": 7
     },
     "Ejectors": {
       "type": "object",
@@ -233,7 +253,9 @@
                 }
               }
             }
-          ]
+          ],
+          "uuid": "4dd1c334-a8d9-48a8-8584-792636a524e9",
+          "index": 0
         },
         "Lowered": {
           "allOf": [
@@ -252,14 +274,22 @@
                 }
               }
             }
-          ]
+          ],
+          "uuid": "17e3836d-45b8-43aa-8a5e-add00d0d446a",
+          "index": 1
         }
       },
       "required": []
+    },
+    "Heaters": {
+      "uuid": "429529d2-fb55-4b07-80b8-a145d931fbef",
+      "index": 15,
+      "patternProperties": {
+        "^[a-zA-Z0-9_]*$": {
+          "$ref": "https://raw.githubusercontent.com/AMRC-FactoryPlus/schemas/main/Press/Heater-v1.json"
+        }
+      },
+      "type": "object"
     }
-  },
-  "required": [
-    "Schema_UUID",
-    "Instance_UUID"
-  ]
+  }
 }

--- a/Press/Press-v1.json
+++ b/Press/Press-v1.json
@@ -258,8 +258,6 @@
       "required": []
     },
     "Heaters": {
-    "uuid": "429529d2-fb55-4b07-80b8-a145d931fbef",
-    "index": 15,
     "patternProperties": {
       "^[a-zA-Z0-9_]*$": {
         "$ref": "https://raw.githubusercontent.com/AMRC-FactoryPlus/schemas/main/Press/Heater-v1.json"

--- a/Press/Tool-v1.json
+++ b/Press/Tool-v1.json
@@ -30,11 +30,21 @@
         }
       ]
     },
-    "Pressure": {
-      "$ref": "https://raw.githubusercontent.com/AMRC-FactoryPlus/schemas/main/Sensors/Pressure-v1.json"
+    "Temperatures": {
+      "patternProperties": {
+        "^[a-zA-Z0-9_]*$": {
+          "$ref": "https://raw.githubusercontent.com/AMRC-FactoryPlus/schemas/main/Sensors/Temperature-v1.json"
+        }
+      },
+      "type": "object"
     },
-    "Temperature": {
-      "$ref": "https://raw.githubusercontent.com/AMRC-FactoryPlus/schemas/main/Sensors/Temperature-v1.json"
+    "Pressures": {
+      "patternProperties": {
+        "^[a-zA-Z0-9_]*$": {
+          "$ref": "https://raw.githubusercontent.com/AMRC-FactoryPlus/schemas/main/Sensors/Pressure-v1.json"
+        }
+      },
+      "type": "object"
     }
   },
   "required": [


### PR DESCRIPTION
Feedback from populating the press schema with data from the 1m press raised some slight changes to requirements. Press schema now includes an array of heaters to avoid the need for different devices using the same connection. Tool schema now includes arrays of pressure and temperature tags rather than single tags to allow for multiple sensors on a single tool.