### PR TITLE
Update Temperature-v1.json

### DIFF
--- a/Sensors/Temperature-v1.json
+++ b/Sensors/Temperature-v1.json
@@ -56,12 +56,28 @@
         {
           "properties": {
             "Documentation": {
-              "default": null
+              "default": "Target temperature set by a controller"
             },
             "Sparkplug_Type": {
               "enum": [
                 "FloatLE",
-                "FloatBE"
+                "FloatBE",
+                "Int8",
+                "Int16LE",
+                "Int16BE",
+                "Int32LE",
+                "Int32BE",
+                "Int64LE",
+                "Int64BE",
+                "UInt8",
+                "UInt16LE",
+                "UInt16BE",
+                "UInt32LE",
+                "UInt32BE",
+                "UInt64LE",
+                "UInt64BE",
+                "DoubleLE",
+                "DoubleBE"
               ]
             }
           }


### PR DESCRIPTION
documentation default being null on setpoint was breaking this schema when deployed in the manager. value has been added and data types have been extended to allow any numerical value.