### PR TITLE
New bottom-level schema for machine states

### DIFF
--- a/Common/State-v1.json
+++ b/Common/State-v1.json
@@ -1,0 +1,51 @@
+{
+  "$id": "https://raw.githubusercontent.com/AMRC-FactoryPlus/schemas/main/Common/State-v1.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "Schema_UUID": {
+      "const": "4b12c922-e09e-4ed8-a14d-544a92e6addb"
+    },
+    "Instance_UUID": {
+      "description": "The unique identifier for this object. (A UUID specified by RFC4122).",
+      "type": "string",
+      "format": "uuid"
+    },
+    "Load": {
+      "allOf": [
+        {
+          "$ref": "https://raw.githubusercontent.com/AMRC-FactoryPlus/schemas/main/Common/Metric-v1.json"
+        },
+        {
+          "properties": {
+            "Documentation": {
+              "default": "example: 0: Idle, 1: Manual, 2: Automatic, 3: Stop"
+            },
+            "Sparkplug_Type": {
+              "enum": [
+                "Int8",
+                "Int16LE",
+                "Int16BE",
+                "Int32LE",
+                "Int32BE",
+                "Int64LE",
+                "Int64BE",
+                "UInt8",
+                "UInt16LE",
+                "UInt16BE",
+                "UInt32LE",
+                "UInt32BE",
+                "UInt64LE",
+                "UInt64BE"
+              ]
+            }
+          }
+        }
+      ]
+    }
+  },
+  "required": [
+    "Schema_UUID",
+    "Instance_UUID"
+  ]
+}


### PR DESCRIPTION
Adds an integer value which represents the state of the machine. Documentation should ideally include a reference for the meaning of each integer.